### PR TITLE
Fix move files bug with multiple file types

### DIFF
--- a/components/dpu-workflow/src/docs_processing_orchestrator.py
+++ b/components/dpu-workflow/src/docs_processing_orchestrator.py
@@ -460,7 +460,7 @@ with DAG(
         >> import_docs_to_data_store
      )
     (
-        create_output_table
+        [create_output_table, move_forms]
         >> create_form_process_job_params
         >> execute_forms_parser
         >> import_forms_to_data_store

--- a/components/dpu-workflow/src/docs_processing_orchestrator.py
+++ b/components/dpu-workflow/src/docs_processing_orchestrator.py
@@ -336,7 +336,7 @@ with DAG(
 
     move_files_done = DummyOperator(
         task_id='move_files_done',
-        trigger_rule=TriggerRule.ALL_DONE
+        trigger_rule=TriggerRule.ALL_SUCCESS
     )
 
     forms_pdf_moved_or_skipped = DummyOperator(


### PR DESCRIPTION
This branch fixes a couple of small issues detected while trying to recreate a bug.
1. DAG was failing when trying to process only unsupported files - where the `create_output_table` step was tried although no run-id was generated by an earlier step since it was skipped.
2. after fixing 1, DAG was failing due to still trying to trigger the `forms_parser` step although no forms were detected.

The original bug could not be reproduce, or was actually fixed implicitly. 